### PR TITLE
Misc cleanups & changes, feel free to pick and choose

### DIFF
--- a/streak.go
+++ b/streak.go
@@ -27,6 +27,7 @@ import (
 
 	"code.google.com/p/goauth2/oauth"
 	"code.google.com/p/google-api-go-client/calendar/v3"
+	"encoding/json"
 )
 
 const (
@@ -37,18 +38,57 @@ const (
 )
 
 var (
-	defaultCacheFile = filepath.Join(os.Getenv("HOME"), ".streak-request-token")
-	cachefile        = flag.String("cachefile", defaultCacheFile, "Authentication token cache file")
-	offset           = flag.Int("offset", 0, "Day offset")
-	remove           = flag.Bool("remove", false, "Remove day from streak")
+	defaultConfigFile = filepath.Join(os.Getenv("HOME"), ".config", "streak", "config.json")
+	configfile        = flag.String("configfile", defaultConfigFile, "Config file")
+	defaultCacheFile  = filepath.Join(os.Getenv("HOME"), ".streak-request-token")
+	cachefile         = flag.String("cachefile", defaultCacheFile, "Authentication token cache file")
+	offset            = flag.Int("offset", 0, "Day offset")
+	remove            = flag.Bool("remove", false, "Remove day from streak")
 )
+
+type Config struct {
+	OAuthId     string
+	OAuthSecret string
+}
+
+func loadConfig() (*Config, error) {
+	conf := Config{
+		OAuthId:     "120233572441-d8vmojicfgje467joivr5a7j52dg2gnc.apps.googleusercontent.com",
+		OAuthSecret: "vfZkluBV6PTfGBWxfIIyXbMS",
+	}
+
+	f, err := os.Open(*configfile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// just use defaults
+			return &conf, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	dec := json.NewDecoder(f)
+	err = dec.Decode(&conf)
+	if err != nil {
+		return nil, err
+	}
+
+	return &conf, nil
+}
 
 func main() {
 	flag.Parse()
 
+	var appconf *Config
+	var err error
+	appconf, err = loadConfig()
+	if err != nil {
+		log.Fatalln("cannot load config:", err)
+	}
+
 	config := &oauth.Config{
-		ClientId:     "120233572441-d8vmojicfgje467joivr5a7j52dg2gnc.apps.googleusercontent.com",
-		ClientSecret: "vfZkluBV6PTfGBWxfIIyXbMS",
+		ClientId:     appconf.OAuthId,
+		ClientSecret: appconf.OAuthSecret,
 		Scope:        "https://www.googleapis.com/auth/calendar",
 		AuthURL:      "https://accounts.google.com/o/oauth2/auth",
 		TokenURL:     "https://accounts.google.com/o/oauth2/token",
@@ -57,7 +97,6 @@ func main() {
 
 	transport := &oauth.Transport{Config: config}
 
-	var err error
 	transport.Token, err = config.TokenCache.Token()
 	if err != nil {
 		// cannot read token cache (and the lib doesn't let us

--- a/streak.go
+++ b/streak.go
@@ -68,12 +68,12 @@ func main() {
 
 	service, err := calendar.New(transport.Client())
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln("instantiate calendar:", err)
 	}
 
 	calId, err := streakCalendarId(service)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln("get calendar id:", err)
 	}
 
 	cal := &Calendar{
@@ -89,7 +89,7 @@ func main() {
 		err = cal.addToStreak(today)
 	}
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln("edit calendar", err)
 	}
 
 	var longest time.Duration

--- a/streak.go
+++ b/streak.go
@@ -104,8 +104,10 @@ func main() {
 		transport.Token = &oauth.Token{}
 	}
 
-	if !transport.Token.Expiry.IsZero() && transport.Token.Expiry.Before(time.Now()) {
-		// cached token has expired, try to refresh
+	if !transport.Token.Expiry.IsZero() &&
+		transport.Token.Expiry.Before(time.Now()) &&
+		transport.Token.RefreshToken != "" {
+		// cached token has expired and we have refresh token, try to refresh
 		// TODO clock drift
 		err = transport.Refresh()
 		if err != nil && err.Error() != "OAuthError: updateToken: 400 Bad Request" {

--- a/streak.go
+++ b/streak.go
@@ -40,7 +40,7 @@ const (
 var (
 	defaultConfigFile = filepath.Join(os.Getenv("HOME"), ".config", "streak", "config.json")
 	configfile        = flag.String("configfile", defaultConfigFile, "Config file")
-	defaultCacheFile  = filepath.Join(os.Getenv("HOME"), ".streak-request-token")
+	defaultCacheFile  = filepath.Join(os.Getenv("HOME"), ".cache", "streak-request-token")
 	cachefile         = flag.String("cachefile", defaultCacheFile, "Authentication token cache file")
 	offset            = flag.Int("offset", 0, "Day offset")
 	remove            = flag.Bool("remove", false, "Remove day from streak")


### PR DESCRIPTION
Hi. I've been using streak for a while as a low-barrier way to record my runs. I ran into a problem with OAuth tokens expiring if I went for two days without a streak -- I had to manually rm the cache file every time -- and ended up futzing with the refresh logic. It now seems to work, whether the token needs refreshing or full reauth.
This is the relevant bug report: https://code.google.com/p/goauth2/issues/detail?id=2

Then, there's a commit that allows using non-public OAuth secrets, because I just didn't know enough of OAuth to trust my calendar to an app that has its secrets on Github.

And then I moved the cache file under ~/.cache, because that seems to be the convention and it's nice to have all always-removable files under one path.

Feel free to cherry-pick and rebase as much as you want.
